### PR TITLE
Now using yarp::dev::ReturnValue

### DIFF
--- a/src/devices/rpLidar/rpLidar.cpp
+++ b/src/devices/rpLidar/rpLidar.cpp
@@ -29,6 +29,8 @@
 
 YARP_LOG_COMPONENT(RPLIDAR, "yarp.device.rpLidar")
 
+using namespace yarp::dev;
+
 rpLidarCircularBuffer::rpLidarCircularBuffer(int bufferSize)
 {
     maxsize = bufferSize + 1;
@@ -206,76 +208,76 @@ bool RpLidar::close()
     return true;
 }
 
-bool RpLidar::getDistanceRange(double& min, double& max)
+ReturnValue RpLidar::getDistanceRange(double& min, double& max)
 {
     std::lock_guard<std::mutex> guard(mutex);
     min = min_distance;
     max = max_distance;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar::setDistanceRange(double min, double max)
+ReturnValue RpLidar::setDistanceRange(double min, double max)
 {
     std::lock_guard<std::mutex> guard(mutex);
     min_distance = min;
     max_distance = max;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar::getScanLimits(double& min, double& max)
+ReturnValue RpLidar::getScanLimits(double& min, double& max)
 {
     std::lock_guard<std::mutex> guard(mutex);
     min = min_angle;
     max = max_angle;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar::setScanLimits(double min, double max)
+ReturnValue RpLidar::setScanLimits(double min, double max)
 {
     std::lock_guard<std::mutex> guard(mutex);
     min_angle = min;
     max_angle = max;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar::getHorizontalResolution(double& step)
+ReturnValue RpLidar::getHorizontalResolution(double& step)
 {
     std::lock_guard<std::mutex> guard(mutex);
     step = resolution;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar::setHorizontalResolution(double step)
+ReturnValue RpLidar::setHorizontalResolution(double step)
 {
     std::lock_guard<std::mutex> guard(mutex);
     resolution = step;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar::getScanRate(double& rate)
+ReturnValue RpLidar::getScanRate(double& rate)
 {
     std::lock_guard<std::mutex> guard(mutex);
     yCWarning(RPLIDAR, "getScanRate not yet implemented");
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar::setScanRate(double rate)
+ReturnValue RpLidar::setScanRate(double rate)
 {
     std::lock_guard<std::mutex> guard(mutex);
     yCWarning(RPLIDAR, "setScanRate not yet implemented");
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
 
-bool RpLidar::getRawData(yarp::sig::Vector &out, double* timestamp)
+ReturnValue RpLidar::getRawData(yarp::sig::Vector &out, double* timestamp)
 {
     std::lock_guard<std::mutex> guard(mutex);
     out = laser_data;
     device_status = yarp::dev::IRangefinder2D::DEVICE_OK_IN_USE;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar::getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp)
+ReturnValue RpLidar::getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp)
 {
     std::lock_guard<std::mutex> guard(mutex);
 #ifdef LASER_DEBUG
@@ -283,7 +285,11 @@ bool RpLidar::getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &
 #endif
     size_t size = laser_data.size();
     data.resize(size);
-    if (max_angle < min_angle) { yCError(RPLIDAR) << "getLaserMeasurement failed"; return false; }
+    if (max_angle < min_angle)
+    {
+        yCError(RPLIDAR) << "getLaserMeasurement failed";
+        return ReturnValue::return_code::return_value_error_method_failed;
+    }
     double laser_angle_of_view = max_angle - min_angle;
     for (size_t i = 0; i < size; i++)
     {
@@ -291,13 +297,13 @@ bool RpLidar::getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &
         data[i].set_polar(laser_data[i], angle);
     }
     device_status = yarp::dev::IRangefinder2D::DEVICE_OK_IN_USE;
-    return true;
+    return ReturnValue_ok;
 }
-bool RpLidar::getDeviceStatus(Device_status &status)
+ReturnValue RpLidar::getDeviceStatus(Device_status &status)
 {
     std::lock_guard<std::mutex> guard(mutex);
     status = device_status;
-    return true;
+    return ReturnValue_ok;
 }
 
 bool RpLidar::threadInit()
@@ -721,9 +727,9 @@ void RpLidar::threadRelease()
     return;
 }
 
-bool RpLidar::getDeviceInfo(std::string &device_info)
+ReturnValue RpLidar::getDeviceInfo(std::string &device_info)
 {
     std::lock_guard<std::mutex> guard(mutex);
     device_info = info;
-    return true;
+    return ReturnValue_ok;
 }

--- a/src/devices/rpLidar/rpLidar.h
+++ b/src/devices/rpLidar/rpLidar.h
@@ -234,18 +234,18 @@ public:
 
 public:
     //IRangefinder2D interface
-    bool getRawData(yarp::sig::Vector &data, double* timestamp) override;
-    bool getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp) override;
-    bool getDeviceStatus     (Device_status &status) override;
-    bool getDeviceInfo       (std::string &device_info) override;
-    bool getDistanceRange    (double& min, double& max) override;
-    bool setDistanceRange    (double min, double max) override;
-    bool getScanLimits        (double& min, double& max) override;
-    bool setScanLimits        (double min, double max) override;
-    bool getHorizontalResolution      (double& step) override;
-    bool setHorizontalResolution      (double step) override;
-    bool getScanRate         (double& rate) override;
-    bool setScanRate         (double rate) override;
+    yarp::dev::ReturnValue getRawData(yarp::sig::Vector &data, double* timestamp) override;
+    yarp::dev::ReturnValue getLaserMeasurement(std::vector<yarp::sig::LaserMeasurementData> &data, double* timestamp) override;
+    yarp::dev::ReturnValue getDeviceStatus     (Device_status &status) override;
+    yarp::dev::ReturnValue getDeviceInfo       (std::string &device_info) override;
+    yarp::dev::ReturnValue getDistanceRange    (double& min, double& max) override;
+    yarp::dev::ReturnValue setDistanceRange    (double min, double max) override;
+    yarp::dev::ReturnValue getScanLimits        (double& min, double& max) override;
+    yarp::dev::ReturnValue setScanLimits        (double min, double max) override;
+    yarp::dev::ReturnValue getHorizontalResolution      (double& step) override;
+    yarp::dev::ReturnValue setHorizontalResolution      (double step) override;
+    yarp::dev::ReturnValue getScanRate         (double& rate) override;
+    yarp::dev::ReturnValue setScanRate         (double rate) override;
 
 public:
     //Lidar2DDeviceBase

--- a/src/devices/rpLidar2/rpLidar2.cpp
+++ b/src/devices/rpLidar2/rpLidar2.cpp
@@ -29,6 +29,7 @@
 //#define FORCE_SCAN
 
 using namespace rp::standalone::rplidar;
+using namespace yarp::dev;
 
 YARP_LOG_COMPONENT(RP2_LIDAR, "yarp.devices.rpLidar2")
 
@@ -166,34 +167,34 @@ bool RpLidar2::close()
     return true;
 }
 
-bool RpLidar2::setDistanceRange(double min, double max)
+ReturnValue RpLidar2::setDistanceRange(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_min_distance = min;
     m_max_distance = max;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar2::setScanLimits(double min, double max)
+ReturnValue RpLidar2::setScanLimits(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_min_angle = min;
     m_max_angle = max;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar2::setHorizontalResolution(double step)
+ReturnValue RpLidar2::setHorizontalResolution(double step)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_resolution = step;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar2::setScanRate(double rate)
+ReturnValue RpLidar2::setScanRate(double rate)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(RP2_LIDAR, "setScanRate not yet implemented");
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
 bool RpLidar2::threadInit()

--- a/src/devices/rpLidar2/rpLidar2.h
+++ b/src/devices/rpLidar2/rpLidar2.h
@@ -77,10 +77,10 @@ public:
 
 public:
     //IRangefinder2D interface
-    bool setDistanceRange     (double min, double max) override;
-    bool setScanLimits        (double min, double max) override;
-    bool setHorizontalResolution      (double step) override;
-    bool setScanRate          (double rate) override;
+    yarp::dev::ReturnValue setDistanceRange     (double min, double max) override;
+    yarp::dev::ReturnValue setScanLimits        (double min, double max) override;
+    yarp::dev::ReturnValue setHorizontalResolution      (double step) override;
+    yarp::dev::ReturnValue setScanRate          (double rate) override;
 
 public:
     //Lidar2DDeviceBase

--- a/src/devices/rpLidar3/rpLidar3.cpp
+++ b/src/devices/rpLidar3/rpLidar3.cpp
@@ -29,6 +29,7 @@
 //#define FORCE_SCAN
 
 using namespace rp::standalone::rplidar;
+using namespace yarp::dev;
 
 YARP_LOG_COMPONENT(RP_LIDAR3, "yarp.devices.RpLidar3")
 
@@ -218,34 +219,34 @@ bool RpLidar3::close()
     return true;
 }
 
-bool RpLidar3::setDistanceRange(double min, double max)
+ReturnValue RpLidar3::setDistanceRange(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_min_distance = min;
     m_max_distance = max;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar3::setScanLimits(double min, double max)
+ReturnValue RpLidar3::setScanLimits(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_min_angle = min;
     m_max_angle = max;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar3::setHorizontalResolution(double step)
+ReturnValue RpLidar3::setHorizontalResolution(double step)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_resolution = step;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar3::setScanRate(double rate)
+ReturnValue RpLidar3::setScanRate(double rate)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(RP_LIDAR3, "setScanRate not yet implemented");
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
 bool RpLidar3::threadInit()

--- a/src/devices/rpLidar3/rpLidar3.h
+++ b/src/devices/rpLidar3/rpLidar3.h
@@ -87,10 +87,10 @@ private:
 
 public:
     //IRangefinder2D interface
-    bool setDistanceRange     (double min, double max) override;
-    bool setScanLimits        (double min, double max) override;
-    bool setHorizontalResolution      (double step) override;
-    bool setScanRate          (double rate) override;
+    yarp::dev::ReturnValue setDistanceRange     (double min, double max) override;
+    yarp::dev::ReturnValue setScanLimits        (double min, double max) override;
+    yarp::dev::ReturnValue setHorizontalResolution      (double step) override;
+    yarp::dev::ReturnValue setScanRate          (double rate) override;
 
 public:
     //Lidar2DDeviceBase

--- a/src/devices/rpLidar4/rpLidar4.cpp
+++ b/src/devices/rpLidar4/rpLidar4.cpp
@@ -29,6 +29,7 @@
 //#define FORCE_SCAN
 
 using namespace rp::standalone::rplidar;
+using namespace yarp::dev;
 
 YARP_LOG_COMPONENT(RP_LIDAR4, "yarp.devices.RpLidar4")
 
@@ -218,34 +219,34 @@ bool RpLidar4::close()
     return true;
 }
 
-bool RpLidar4::setDistanceRange(double min, double max)
+ReturnValue RpLidar4::setDistanceRange(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_min_distance = min;
     m_max_distance = max;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar4::setScanLimits(double min, double max)
+ReturnValue RpLidar4::setScanLimits(double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_min_angle = min;
     m_max_angle = max;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar4::setHorizontalResolution(double step)
+ReturnValue RpLidar4::setHorizontalResolution(double step)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     m_resolution = step;
-    return true;
+    return ReturnValue_ok;
 }
 
-bool RpLidar4::setScanRate(double rate)
+ReturnValue RpLidar4::setScanRate(double rate)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCWarning(RP_LIDAR4, "setScanRate not yet implemented");
-    return false;
+    return ReturnValue::return_code::return_value_error_not_implemented_by_device;
 }
 
 bool RpLidar4::threadInit()

--- a/src/devices/rpLidar4/rpLidar4.h
+++ b/src/devices/rpLidar4/rpLidar4.h
@@ -87,10 +87,10 @@ private:
 
 public:
     //IRangefinder2D interface
-    bool setDistanceRange     (double min, double max) override;
-    bool setScanLimits        (double min, double max) override;
-    bool setHorizontalResolution      (double step) override;
-    bool setScanRate          (double rate) override;
+    yarp::dev::ReturnValue setDistanceRange     (double min, double max) override;
+    yarp::dev::ReturnValue setScanLimits        (double min, double max) override;
+    yarp::dev::ReturnValue setHorizontalResolution      (double step) override;
+    yarp::dev::ReturnValue setScanRate          (double rate) override;
 
 public:
     //Lidar2DDeviceBase


### PR DESCRIPTION
Methods belonging to `IRangefinder2D` interface now use `yarp::dev::ReturnValue`.

- [X] Requires YARP 3.11.100

- [x] TO BE REBASED after #6

- [x] A TAG OF THIS REPO IS RECOMMENDED BEFORE MERGING THIS PR



