### PR TITLE
Add missing sdk components to CMakeLists

### DIFF
--- a/src/devices/rpLidar4/CMakeLists.txt
+++ b/src/devices/rpLidar4/CMakeLists.txt
@@ -22,12 +22,18 @@ if(NOT SKIP_rpLidar4)
 
   set(RPLIDAR_SDK_SRCS
     ${RPLIDAR_21_SDK_ROOT}/src/rplidar_driver.cpp
+    ${RPLIDAR_21_SDK_ROOT}/src/sl_lidarprotocol_codec.cpp
+    ${RPLIDAR_21_SDK_ROOT}/src/sl_async_transceiver.cpp
     ${RPLIDAR_21_SDK_ROOT}/src/sl_lidar_driver.cpp
     ${RPLIDAR_21_SDK_ROOT}/src/sl_serial_channel.cpp
     ${RPLIDAR_21_SDK_ROOT}/src/sl_tcp_channel.cpp
     ${RPLIDAR_21_SDK_ROOT}/src/sl_udp_channel.cpp
     ${RPLIDAR_21_SDK_ROOT}/src/sl_crc.cpp
 
+    ${RPLIDAR_21_SDK_ROOT}/src/dataunpacker/dataunpacker.cpp
+    ${RPLIDAR_21_SDK_ROOT}/src/dataunpacker/unpacker/handler_capsules.cpp
+    ${RPLIDAR_21_SDK_ROOT}/src/dataunpacker/unpacker/handler_hqnode.cpp
+    ${RPLIDAR_21_SDK_ROOT}/src/dataunpacker/unpacker/handler_normalnode.cpp
     ${RPLIDAR_21_SDK_ROOT}/src/arch/${RPLIDAR_ARCH_DIR}/net_serial.cpp
     ${RPLIDAR_21_SDK_ROOT}/src/arch/${RPLIDAR_ARCH_DIR}/net_socket.cpp
     ${RPLIDAR_21_SDK_ROOT}/src/arch/${RPLIDAR_ARCH_DIR}/timer.cpp


### PR DESCRIPTION
During the startup of yarprobotinterface, I encountered different errors related to the LiDAR module. Specifically, the command returns the following message among others:

`yarprobotinterface: symbol lookup error: /usr/local/src/robot/robotology-superbuild/build/install/lib/yarp/yarp_rpLidar4.so: undefined symbol: _ZN2sl8internal20RPLidarProtocolCodecC1Ev `

Some files containing functions required by yarp/yarp_rpLidar4.so were not included in the CMakeLists.txt of yarp-device-rplidar. I fixed this by adding the missing SDK files.

This error occured on the tag v1.0

My robotology-superbuild version:
YARP version 3.11.2+16-20250512.3+git83a03ebfa
robotology-superbuild v2025.02.0

